### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,93 +49,99 @@ add it to your $PATH.
 
     `DockerToolbox-.exe /COMPONENTS="Docker,DockerMachine"`
 
-2.  Replace contents of `C:\Program Files\Docker Toolbox\start.sh` with this script.
+2.  Replace contents of `**Your Docker Toolbox Installation Directory**\start.sh` with this script.
 
-    ```none
-    #!/bin/bash
+    **Notes**: 
+    - Replace the path with your VMware Installation Directory before replacement.
+    - This script is only tested on bash from git.
+    - It should be suitable for all bash supported program with WIN32-application-executable ability (means pure Linux environment like WSL can't make it).
 
-    export PATH="$PATH:/mnt/c/Program Files (x86)/VMware/VMware Workstation"
+        ```none
+        #!/bin/bash
 
-    trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP´... Press any key to continue..."' EXIT
+        #example "$PATH:/c/Program Files (x86)/VMware/VMware Workstation"
+        export PATH="$PATH:**Your VMware Workstation Installation Directory**"
 
-    VM=${DOCKER_MACHINE_NAME-default}
-    DOCKER_MACHINE=./docker-machine.exe
+        trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP´... Press any key to continue..."' EXIT
 
-    BLUE='\033[1;34m'
-    GREEN='\033[0;32m'
-    NC='\033[0m'
+        VM=${DOCKER_MACHINE_NAME-default}
+        DOCKER_MACHINE=./docker-machine.exe
 
-
-    if [ ! -f "${DOCKER_MACHINE}" ]; then
-      echo "Docker Machine is not installed. Please re-run the Toolbox Installer and try again."
-      exit 1
-    fi
-
-    vmrun.exe list | grep \""${VM}"\" &> /dev/null
-    VM_EXISTS_CODE=$?
-
-    set -e
-
-    STEP="Checking if machine $VM exists"
-    if [ $VM_EXISTS_CODE -eq 1 ]; then
-      "${DOCKER_MACHINE}" rm -f "${VM}" &> /dev/null || :
-      rm -rf ~/.docker/machine/machines/"${VM}"
-      #set proxy variables if they exists
-      if [ -n ${HTTP_PROXY+x} ]; then
-        PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
-      fi
-      if [ -n ${HTTPS_PROXY+x} ]; then
-        PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$HTTPS_PROXY"
-      fi
-      if [ -n ${NO_PROXY+x} ]; then
-        PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
-      fi  
-      "${DOCKER_MACHINE}" create -d vmwareworkstation $PROXY_ENV "${VM}"
-    fi
-
-    STEP="Checking status on $VM"
-    VM_STATUS="$(${DOCKER_MACHINE} status ${VM} 2>&1)"
-    if [ "${VM_STATUS}" != "Running" ]; then
-      "${DOCKER_MACHINE}" start "${VM}"
-      yes | "${DOCKER_MACHINE}" regenerate-certs "${VM}"
-    fi
-
-    STEP="Setting env"
-    eval "$(${DOCKER_MACHINE} env --shell=bash ${VM})"
-
-    STEP="Finalize"
-    clear
-    cat << EOF
+        BLUE='\033[1;34m'
+        GREEN='\033[0;32m'
+        NC='\033[0m'
 
 
-                            ##         .
-                      ## ## ##        ==
-                   ## ## ## ## ##    ===
-               /"""""""""""""""""\___/ ===
-          ~~~ {~~ ~~~~ ~~~ ~~~~ ~~~ ~ /  ===- ~~~
-               \______ o           __/
-                 \    \         __/
-                  \____\_______/
+        if [ ! -f "${DOCKER_MACHINE}" ]; then
+          echo "Docker Machine is not installed. Please re-run the Toolbox Installer and try again."
+          exit 1
+        fi
 
-    EOF
-    echo -e "${BLUE}docker${NC} is configured to use the ${GREEN}${VM}${NC} machine with IP ${GREEN}$(${DOCKER_MACHINE} ip ${VM})${NC}"
-    echo "For help getting started, check out the docs at https://docs.docker.com"
-    echo
-    cd
+        vmrun.exe list | grep "${VM}" &> /dev/null
+        VM_EXISTS_CODE=$?
 
-    docker () {
-      MSYS_NO_PATHCONV=1 docker.exe "$@"
-    }
-    export -f docker
+        set -e
 
-    if [ $# -eq 0 ]; then
-      echo "Start interactive shell"
-      exec "$BASH" --login -i
-    else
-      echo "Start shell with command"
-      exec "$BASH" -c "$*"
-    fi
-    ```
+        STEP="Checking if machine $VM exists"
+        if [ ! $VM_EXISTS_CODE -eq 1 ] && [ ! -d ~/.docker/machine/machines/"${VM}" ]; then
+          "${DOCKER_MACHINE}" rm -f "${VM}" &> /dev/null || :
+          rm -rf ~/.docker/machine/machines/"${VM}"
+          #set proxy variables if they exists
+          if [ -n ${HTTP_PROXY+x} ]; then
+            PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
+          fi
+          if [ -n ${HTTPS_PROXY+x} ]; then
+            PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$HTTPS_PROXY"
+          fi
+          if [ -n ${NO_PROXY+x} ]; then
+            PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
+          fi  
+          "${DOCKER_MACHINE}" create -d vmwareworkstation $PROXY_ENV "${VM}"
+        fi
+
+        STEP="Checking status on $VM"
+        VM_STATUS="$(${DOCKER_MACHINE} status ${VM} 2>&1)"
+        if [ "${VM_STATUS}" != "Running" ]; then
+          "${DOCKER_MACHINE}" start "${VM}"
+          yes | "${DOCKER_MACHINE}" regenerate-certs "${VM}"
+        fi
+
+        STEP="Setting env"
+        eval "$(${DOCKER_MACHINE} env --shell=bash ${VM})"
+
+        STEP="Finalize"
+        clear
+        cat << EOF
+
+
+                                ##         .
+                          ## ## ##        ==
+                       ## ## ## ## ##    ===
+                   /"""""""""""""""""\___/ ===
+              ~~~ {~~ ~~~~ ~~~ ~~~~ ~~~ ~ /  ===- ~~~
+                   \______ o           __/
+                     \    \         __/
+                      \____\_______/
+
+        EOF
+        echo -e "${BLUE}docker${NC} is configured to use the ${GREEN}${VM}${NC} machine with IP ${GREEN}$(${DOCKER_MACHINE} ip ${VM})${NC}"
+        echo "For help getting started, check out the docs at https://docs.docker.com"
+        echo
+        cd
+
+        docker () {
+          MSYS_NO_PATHCONV=1 docker.exe "$@"
+        }
+        export -f docker
+
+        if [ $# -eq 0 ]; then
+          echo "Start interactive shell"
+          exec "$BASH" --login -i
+        else
+          echo "Start shell with command"
+          exec "$BASH" -c "$*"
+        fi
+        ```
 
     Credit for the above script to [@gtirloni](https://github.com/gtirloni)
 


### PR DESCRIPTION
## Changes
- add notes.
- modified start.sh.
## Reason
- "vmrum.exe list" command just list the running VMs, not all registed VMs like Virtual Box

So, just changed the "if" condition and added a checker for the files of  the docker VM. And the creating action will only be triggered when the target VM were not running and the VM's files were not exist. 
Actually It's not a permanent solution at all.